### PR TITLE
Add ChatPage tts and playing gif

### DIFF
--- a/lib/screen/root.dart
+++ b/lib/screen/root.dart
@@ -67,6 +67,7 @@ class _Navigation_GreedotState extends State<Navigation_Greedot> {
 
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: const Text("Greedot"),
         backgroundColor: colorMainBG_greedot,
         centerTitle: false,


### PR DESCRIPTION
 ## Work summary

     GetChatBotMessage 수정
     fetchGreeGifs 추가
     gifPlayer.dart 추가 
     ChatPage TTS 기능 추가, Gif 띄우기, 백엔드 연동

 ## key change

     그리 생성 후 ChatPage로 넘어가는건 추후 진행 예정입니다.
     특정 단어에 맞는 GIF 실행 로직 추가 수정 예정입니다.
 
 
 ## How to use

     ChatPage 실행을 위해  pubsec.yaml에 just_audio: ^0.9.14 추가해야합니다.
     

 ## issue num(optional)
    
     addFavorite.dart 파일 77번째 라인 greeId : widget.gree.id 로 수정해야합니다.
     